### PR TITLE
Add gaia icons resources to the bower dist assets

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -5,7 +5,7 @@
   "authors": [
     "Wilson Page <wilsonpage@me.com>"
   ],
-  "main": "gaia-icons.js",
+  "main": ["gaia-icons.js", "gaia-icons.css", "fonts/gaia-icons.ttf"],
   "license": "MIT",
   "ignore": [
     "**/.*",

--- a/bower.json
+++ b/bower.json
@@ -5,7 +5,12 @@
   "authors": [
     "Wilson Page <wilsonpage@me.com>"
   ],
-  "main": ["gaia-icons.js", "gaia-icons.css", "fonts/gaia-icons.ttf", "gaia-icons-embedded.css"],
+  "main": [
+    "gaia-icons.js",
+    "gaia-icons.css",
+    "fonts/gaia-icons.ttf",
+    "gaia-icons-embedded.css"
+  ],
   "license": "MIT",
   "ignore": [
     "**/.*",

--- a/bower.json
+++ b/bower.json
@@ -5,7 +5,7 @@
   "authors": [
     "Wilson Page <wilsonpage@me.com>"
   ],
-  "main": ["gaia-icons.js", "gaia-icons.css", "fonts/gaia-icons.ttf"],
+  "main": ["gaia-icons.js", "gaia-icons.css", "fonts/gaia-icons.ttf", "gaia-icons-embedded.css"],
   "license": "MIT",
   "ignore": [
     "**/.*",


### PR DESCRIPTION
This allows one to for example use grunt-bower to pull out the required assets from the bower module. Currently this would only copy the js file, which is of no use alone (or in any context that's not bower_components anyways).