### PR TITLE
Bug 1209961 - Add bidi-helper to the list of distributed files.

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -9,7 +9,8 @@
     "gaia-icons.js",
     "gaia-icons.css",
     "fonts/gaia-icons.ttf",
-    "gaia-icons-embedded.css"
+    "gaia-icons-embedded.css",
+    "bidi-helper.css"
   ],
   "license": "MIT",
   "ignore": [


### PR DESCRIPTION
hey @wilsonpage I think I forgot to add `bidi-helper.css` to the list of distributed files. Is it done this way? Sorry for the noise :-/